### PR TITLE
fix: unpin action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       RENOVATE_CONFIG_FILE: ${{ matrix.file }}.json
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
 
       - name: testing ${{ matrix.file }}
         run: npx -p renovate renovate-config-validator


### PR DESCRIPTION
We don't have renovate enabled here, so do not pin any action.