### PR TITLE
chore: create repo description, add test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+![test](https://github.com/renovatebot/.github/workflows/test/badge.svg)
+
 # .github
+
+This repository contains the basic Renovate configuration that is used in most/all other Renovate repositories.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 # .github
 
-This repository contains the basic Renovate configuration that is used in most/all other Renovate repositories.
+This repository contains the basic Renovate configuration that is used in most/all other renovatebot repositories.


### PR DESCRIPTION
## Changes:

- Add test badge to show that the `renovate-config-validator` passes/fails
- Add description to explain what this repo is about.

## Context:

If a new user lands on this repository it might not be clear what this repository is doing.
I think it's good to explain what this repo is about.

Might be good to fill in the repository "About" sidebar as well.