### PR TITLE
fix: disable major and minor on rebuild trigger

### DIFF
--- a/default.json
+++ b/default.json
@@ -84,6 +84,12 @@
       "description": "Restrict husky to v4 due to commercial license for v5",
       "packageNames": ["husky"],
       "allowedVersions": "<5"
+    },
+    {
+      "description": "Only patch updates on renovate rebuild trigger files",
+      "matchFiles": ["renovate.Dockerfile"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
These files are use to trigger a rebuild on master.