### PR TITLE
feat: allow husky v6 updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -81,11 +81,6 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "Restrict husky to v4 due to commercial license for v5",
-      "packageNames": ["husky"],
-      "allowedVersions": "<5"
-    },
-    {
       "description": "Only patch updates on renovate rebuild trigger files",
       "matchFiles": ["renovate.Dockerfile"],
       "separateMinorPatch": true


### PR DESCRIPTION
husky is now MIT again, but needs manual migration.

closes #17 