### PR TITLE
feat: update GitHub Action references in readme.md

### DIFF
--- a/default.json
+++ b/default.json
@@ -105,6 +105,16 @@
       "versioningTemplate": "docker"
     },
     {
+      "description": "Update Github Action references in the markdown files",
+      "fileMatch": ["\\.md$"],
+      "matchStrings": [
+        "\\suses: (?<depName>actions\\/checkout)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "\\suses: (?<depName>renovatebot\\/github-action)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    },
+    {
       "description": "Update _VERSION variables in Dockerfiles",
       "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile\\.[^/]*$"],
       "matchStrings": [


### PR DESCRIPTION
## Changes:

- Create rough draft that updates references to GitHub Action version numbers in `readme.md` on `renovatebot/github-action` repository

## Context:

Needs more work, so do not merge until ready! 😄 

I accidentally closed my fork... So this is a retry of PR #20.