### PR TITLE
chore: get major updates that pass tests

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,7 +21,7 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "description": "Get PRs for major updates that pass the tests, exclude Renovate packages"
+      "description": "Get PRs for major updates that pass the tests, exclude Renovate packages",
       "excludePackagePatterns": ["^renovate(bot)?($|/)"],
       "matchUpdateTypes": ["major"],
       "prCreation": "status-success",

--- a/default.json
+++ b/default.json
@@ -21,10 +21,11 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "description": "Require dashboard approval for major updates except Renovate",
+      "description": "Get PRs for major updates that pass the tests, exclude Renovate packages"
       "excludePackagePatterns": ["^renovate(bot)?($|/)"],
       "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
+      "prCreation": "status-success",
+      "rebaseWhen": "conflicted"
     },
     {
       "description": "Automerge non-major updates",


### PR DESCRIPTION
## Changes:

- Create a config that will get us "easy major updates" automatically

## Context:

Right now we have to click on major type updates on our Dependency Dashboard to try out the update on a branch with tests. This means that we won't know if any `major` type update is actually an easy merge until we do manual work to get the update PR from Renovate.

I think we can improve our workflow by letting Renovate:

1. Create a branch for `major` type updates, and do not open PR yet
2. GitHub runs tests on the branch
3. If test pass -> open PR for `major` update (probably an easy merge)
4. If tests fail -> do not open PR, wait for a maintainer to "force" the PR via the Dependency Dashboard.