### PR TITLE
fix: no stabillity days for aws-sdk

### DIFF
--- a/default.json
+++ b/default.json
@@ -94,7 +94,8 @@
       "matchDatasources": ["npm"],
       "matchPackageNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk\\/"],
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "stabilityDays": 0
     },
     {
       "description": "Only patch updates on renovate rebuild trigger files",


### PR DESCRIPTION
We use dashboard approval, so we don't need that. package versions are getting out of sync otherwise

- https://github.com/renovatebot/renovate/pull/20014