### PR TITLE
fix: don't pin devcontainer digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -116,9 +116,9 @@
       "semanticCommitType": "fix"
     },
     {
-      "description": "don't pin our node devcontainer digest",
+      "description": "don't pin our devcontainer digests",
       "matchFiles": [".devcontainer/Dockerfile"],
-      "matchPackageNames": ["ghcr.io/containerbase/node"],
+      "matchPackageNames": ["ghcr.io/containerbase/node", "ghcr.io/containerbase/base"],
       "pinDigests": false
     }
   ],


### PR DESCRIPTION
add `ghcr.io/containerbase/base`

https://github.com/renovatebot/helm-charts/blob/13a83ceeb69fc36b9084bbdd3161e6dcbb80bd45/.devcontainer/Dockerfile#L1