### PR TITLE
feat: enable `yarnDedupeHighest`

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,6 +19,7 @@
   "rebaseWhen": "behind-base-branch",
   "platformAutomerge": true,
   "internalChecksFilter": "strict",
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "description": "Pin digests for dockerfile and docker-compose managers",


### PR DESCRIPTION
otherwise we get a lot duplicates until next lockfile maintenance. Those duplicates already caused errors on renovate repo