### PR TITLE
feat: prevent automerging pre-1.0.0 versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -40,6 +40,7 @@
     {
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
+      "matchCurrentVersion": "!/^0/",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Changes:

- Add `"matchCurrentVersion": "!/^0/",` to our "Automerge non-major updates" rule

## Context:

Renovate recently automerged a pre-1.x update:

- https://github.com/renovatebot/renovate/pull/23598

I expected us to block updates like these, because of this quote from our docs: [^1]

> The `matchCurrentVersion` setting above is a rule to exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time according to the SemVer spec.

So I copy/pasted the code into our own config. 🙃 But maybe we have good reasons to keep things as they are?

[^1]: [Renovate docs, automerge non-major updates](https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates)