### PR TITLE
chore: update security instructions and email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,7 @@
-# Security Policy
+# Security / Disclosure
 
-Please send an email to [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com) describing what you have found. Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first.
+If you find any bug that may be a security problem, then e-mail us at: [renovate-disclosure@mend.io](mailto:renovate-disclosure@mend.io).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues or Discussions for security-related doubts or problems.


### PR DESCRIPTION
## Changes:

- Change heading to `Security / Disclosure`
- This is basically a copy/paste from the [main renovatebot repository's `security.md` file](https://github.com/renovatebot/renovate/blob/main/SECURITY.md), but I'm removing the `with Renovate` qualifier

## Context:

I wanted to edit the `SECURITY.md` on the new reproductions template repository, but the edit button took me to this repository. :smile: 

I think this `SECURITY.md` applies to all repositories under the `renovatebot` organizations, that do not have their own repository-specific `SECURITY.md` file?

Also, should we remove the `SECURITY.md` file on the main Renovate repository, and only use the template in this `.github` repository?