### PR TITLE
fix: defer our prebuild updates for slow arm64 builds

### DIFF
--- a/default.json
+++ b/default.json
@@ -124,6 +124,11 @@
       "matchPackageNames": ["ghcr.io/containerbase/base", "ghcr.io/containerbase/devcontainer", "ghcr.io/containerbase/gitpod", "ghcr.io/containerbase/node"],
       "semanticCommitType": "chore",
       "pinDigests": false
+    },
+    {
+      "description": "defer prebuild updates to wait for arm64 builds",
+      "matchPackageNames": ["/^containerbase/.+-prebuild$/"],
+      "minimumReleaseAge": "2h"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
The base image depends on them because it's build for arm64. This gives the arm64 builds two more hours to build.

- https://github.com/containerbase/internal-tools/issues/242