### PR TITLE
chore(renovate): apply `minimumReleaseAge` to AWS SDK updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -98,8 +98,7 @@
       "description": "Schedule monthly for aws-sdk as it updates too often",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["aws-sdk", "/^@aws-sdk//"],
-      "extends": ["schedule:monthly"],
-      "minimumReleaseAge": null
+      "extends": ["schedule:monthly"]
     },
     {
       "description": "Only patch updates on renovate rebuild trigger files",


### PR DESCRIPTION
As we're now enforcing `minimumReleaseAge` in our `pnpm` config, we
should make sure that monthly updates still abide by this.
